### PR TITLE
Indexable MultiCellModel and default parameters

### DIFF
--- a/cbcbeat/cellmodels/cardiaccellmodel.py
+++ b/cbcbeat/cellmodels/cardiaccellmodel.py
@@ -166,6 +166,9 @@ class MultiCellModel(CardiacCellModel):
 
         self._num_states = max(c.num_states() for c in self._cell_models)
 
+    def __getitem__(self, key):
+        return self.models()[self._key_to_cell_model[key]]
+
     def models(self):
         return self._cell_models
 

--- a/cbcbeat/gossplittingsolver.py
+++ b/cbcbeat/gossplittingsolver.py
@@ -88,7 +88,7 @@ class GOSSplittingSolver:
 
 
         # Add default parameters from ODE solver
-        ode_solver_params = DOLFINODESystemSolver.default_parameters()
+        ode_solver_params = DOLFINODESystemSolver.default_parameters_dolfin()
         ode_solver_params.rename("ode_solver")
         #ode_solver_params.add("membrane_potential", "V")
         params.add(ode_solver_params)


### PR DESCRIPTION
In goss the `default_parameters` returned by the `DOLFINODESystemSolver` is currently a python dictionary and not a `dolfin.Parameters` object. I think we should avoid using the `Parameters` in goss since the bindings to C++ is very complicated and adds a lot of complexity. Therefore I implemented a different static method called `default_parameters_dolfin` on `DOLFINODESystemSolver` that is called here instead. 

Also, I implemented a `__ getitem__` method for `MultiCellModel` so that when you have a `MultiCellModel` with e.g 2 keys, say `10` and `20`, then you can get the first model by using
```python
model = cellmodels[10]
```
(currently you need to do `cellmodels.models()[cellmodels._key_to_cell_model[key]]`
We should probably also add a test for this but I couldn't find any tests for `MultiCellModel` so I guess we can add this later.