### PR TITLE
Make GOSSplittingsolver compatible with regular SplittingSolver

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,7 +7,7 @@ version: 2.1
 executors:
   fenics-latest:
     docker:
-      - image: quay.io/fenicsproject/stable:latest
+      - image: finsberg/fenics:latest
   fenics-adjoint-latest:
     docker:
       - image: quay.io/dolfinadjoint/pyadjoint:latest

--- a/cbcbeat/cellmodels/simple_model.ode
+++ b/cbcbeat/cellmodels/simple_model.ode
@@ -1,0 +1,7 @@
+states("Membrane",
+       v = 0.0,
+       s = 0.0)
+
+# Time derivatives
+dv_dt = -s
+ds_dt = v

--- a/cbcbeat/cellmodels/simple_model.ode
+++ b/cbcbeat/cellmodels/simple_model.ode
@@ -3,5 +3,5 @@ states("Membrane",
        s = 0.0)
 
 # Time derivatives
-dv_dt = -s
+dv_dt = s
 ds_dt = v

--- a/cbcbeat/gossplittingsolver.py
+++ b/cbcbeat/gossplittingsolver.py
@@ -8,6 +8,7 @@ __all__ = ["GOSSplittingSolver"]
 
 import numpy as np
 import types
+from cbcbeat.cellmodels.cardiaccellmodel import MultiCellModel
 
 from dolfin import *
 from dolfin.cpp.log import log, LogLevel
@@ -18,49 +19,18 @@ import gotran
 
 from goss.dolfinutils import DOLFINODESystemSolver
 
-#if "DOLFINODESystemSolver" not in goss.__dict__:
+# if "DOLFINODESystemSolver" not in goss.__dict__:
 #    raise ImportError("goss could not import DOLFINODESystemSolver")
 
 # Beatadjoint imports
 from cbcbeat.bidomainsolver import BidomainSolver
 from cbcbeat.monodomainsolver import MonodomainSolver
 from cbcbeat.cardiacmodels import CardiacModel
+from cbcbeat.splittingsolver import SplittingSolver
 from cbcbeat.utils import TimeStepper, Projecter
 
 
-class GOSSplittingSolver:
-
-    def __init__(self, model, params=None):
-
-        # Check some input
-        assert isinstance(model, CardiacModel), \
-            "Expecting the model to be CardiacModel, not %r" % model
-
-        # Set model and parameters
-        self._model = model
-        self.parameters = self.default_parameters()
-        if params is not None:
-            self.parameters.update(params)
-
-        # Extract solution domain and time
-        self._domain = self._model.domain()
-        self._time = self._model.time()
-
-        # Create PDE solver and extract solution fields
-        self.pde_solver = self._create_pde_solver()
-        (self.v, self.vur) = self.pde_solver.solution_fields()
-
-        # Create ODE solver and extract solution fields
-        self.ode_solver = self._create_ode_solver()
-
-        if params and "enable_adjoint" in params and params["enable_adjoint"]:
-            raise RuntimeError("GOSS is not compatible with dolfin-adjoint. "\
-                               "params['enable_adjoint'] must be false ")
-
-        # Set-up projection solver (for optimised merging) of fields
-        self.vs_projecter = Projecter(self.v.function_space(),
-                                      params=self.parameters["Projecter"])
-
+class GOSSplittingSolver(SplittingSolver):
     @staticmethod
     def default_parameters():
         """Initialize and return a set of default parameters for the
@@ -86,11 +56,10 @@ class GOSSplittingSolver:
             params.add("pde_solver", "bidomain", ["bidomain", "monodomain"])
             pass
 
-
         # Add default parameters from ODE solver
         ode_solver_params = DOLFINODESystemSolver.default_parameters_dolfin()
         ode_solver_params.rename("ode_solver")
-        #ode_solver_params.add("membrane_potential", "V")
+        # ode_solver_params.add("membrane_potential", "V")
         params.add(ode_solver_params)
 
         pde_solver_params = BidomainSolver.default_parameters()
@@ -106,42 +75,6 @@ class GOSSplittingSolver:
 
         return params
 
-    def _create_pde_solver(self):
-        """Helper function to initialize a suitable PDE solver from
-        the cardiac model."""
-
-        # Extract applied current from the cardiac model (stimulus
-        # invoked in the ODE step)
-        applied_current = self._model.applied_current
-
-        # Extract stimulus from the cardiac model(!)
-        if self.parameters["apply_stimulus_current_to_pde"]:
-            stimulus = self._model.stimulus()
-        else:
-            stimulus = None
-
-        # Extract conductivities from the cardiac model
-        (M_i, M_e) = self._model.conductivities()
-
-        if self.parameters["pde_solver"] == "bidomain":
-            PDESolver = BidomainSolver
-            params = self.parameters["BidomainSolver"]
-            args = (self._domain, self._time, M_i, M_e)
-            kwargs = dict(I_s=stimulus, I_a=applied_current, params=params)
-        else:
-            PDESolver = MonodomainSolver
-            params = self.parameters["MonodomainSolver"]
-            args = (self._domain, self._time, M_i,)
-            kwargs = dict(I_s=stimulus, params=params)
-
-        # Propagate enable_adjoint to Bidomain solver
-        if params.has_parameter("enable_adjoint"):
-            params["enable_adjoint"] = self.parameters["enable_adjoint"]
-
-        solver = PDESolver(*args, **kwargs)
-
-        return solver
-
     def _create_ode_solver(self):
         """Helper function to initialize a suitable ODE solver from
         the cardiac model."""
@@ -149,137 +82,14 @@ class GOSSplittingSolver:
         # Extract cardiac cell model from cardiac model
         cell_models = self._model.cell_models()
 
-        # Create DOLFINODESystemSolver
-        solver = DOLFINODESystemSolver(self._domain, \
-                                       dict(zip(cell_models.keys(), cell_models.models())),
-                                       domains=cell_models.markers(), \
-                                       params=self.parameters["ode_solver"])
+        kwargs = {"odes": cell_models}
+        if isinstance(cell_models, MultiCellModel):
+            kwargs = {
+                "odes": dict(zip(cell_models.keys(), cell_models.models())),
+                "domains": cell_models.markers(),
+            }
 
+        solver = DOLFINODESystemSolver(
+            self._domain, params=self.parameters["ode_solver"], **kwargs
+        )
         return solver
-
-    def solution_fields(self):
-        """
-        Return tuple of previous and current solution objects.
-
-        Modifying these will modify the solution objects of the solver
-        and thus provides a way for setting initial conditions for
-        instance.
-
-        *Returns*
-          (current v, current vur) (:py:class:`tuple` of :py:class:`dolfin.Function`)
-        """
-        return (self.v, self.vur)
-
-    def solve(self, interval, dt):
-        """
-        Solve the problem given by the model on a given time interval
-        (t0, t1) with a given timestep dt and return generator for a
-        tuple of the time step and the solution fields.
-
-        *Arguments*
-          interval (:py:class:`tuple`)
-            The time interval for the solve given by (t0, t1)
-          dt (int)
-            The timestep for the solve
-
-        *Returns*
-          (timestep, solution_fields) via (:py:class:`genexpr`)
-
-        *Example of usage*::
-
-          # Create generator
-          solutions = solver.solve((0.0, 1.0), 0.1)
-
-          # Iterate over generator (computes solutions as you go)
-          for ((t0, t1), (v, vur)) in solutions:
-            # do something with the solutions
-
-        """
-        # Create timestepper
-        time_stepper = TimeStepper(interval, dt, \
-                                   annotate=self.parameters["enable_adjoint"])
-
-        for t0, t1 in time_stepper:
-
-            log(LogLevel.INFO, "Solving on t = (%g, %g)" % (t0, t1))
-            self.step((t0, t1))
-
-            # Yield solutions
-            yield (t0, t1), self.solution_fields()
-
-
-    def step(self, interval):
-        """
-        Solve the problem given by the model on a given time interval
-        (t0, t1) with timestep given by the interval length.
-
-        *Arguments*
-          interval (:py:class:`tuple`)
-            The time interval for the solve given by (t0, t1)
-
-        *Invariants*
-          Given self._vs in a correct state at t0, provide v and s (in
-          self.vs) and u (in self.vur) in a correct state at t1. (Note
-          that self.vur[0] == self.vs[0] only if theta = 1.0.)
-        """
-
-        # Extract some parameters for readability
-        theta = self.parameters["theta"]
-
-        # Extract time domain
-        (t0, t1) = interval
-        dt = (t1 - t0)
-        t = t0 + theta*dt
-
-        # Compute tentative membrane potential and state (vs_star)
-        begin("Tentative ODE step")
-
-        # Assumes that ode_solver is in the correct state
-        self.ode_solver.step((t0, t), self.v)
-        end()
-
-        # Compute tentative potentials vu = (v, u)
-        begin("PDE step")
-        # Assumes that its v is in the correct state, gives vur in
-        # the current state
-        self.pde_solver.step((t0, t1))
-        self.merge(self.v)
-        end()
-
-        # If first order splitting, we need to ensure that self.vs is
-        # up to date, but otherwise we are done.
-        if theta == 1.0:
-            # Assumes that the v part of its vur and v is in same state
-            return
-
-        # Otherwise, we do another ode_step:
-        begin("Corrective ODE step")
-
-        # Assumes that v is in the correct state, updates v in
-        # the correct state
-        self.ode_solver.step((t, t1), self.v)
-        end()
-
-    def merge(self, solution):
-        """
-        Extract membrane potential from solutions from the PDE solve and put
-        it into membrane potential used for the ODE solve.
-
-        *Arguments*
-          solution (:py:class:`dolfin.Function`)
-            Function holding the combined result
-        """
-        # Disabled for now (does not pass replay)
-
-        begin("Merging using custom projecter")
-        if self.parameters["pde_solver"] == "bidomain":
-            v = split(self.vur)[0]
-            solution.vector()[:] = project(v, solution.function_space()).vector()
-        else:
-            solution.vector()[:] = self.vur.vector()
-
-        # FIXME: We should not need to do a projection. A sub function assign would
-        # FIXME: be sufficient.
-        # FIXME: Does not work in parallel!!!
-        #self.vs_projecter(v, solution)
-        end()

--- a/cbcbeat/splittingsolver.py
+++ b/cbcbeat/splittingsolver.py
@@ -107,12 +107,15 @@ class BasicSplittingSolver:
         a CardiacModel object describing the simulation set-up
       params (:py:class:`dolfin.Parameters`, optional)
         a Parameters object controlling solver parameters
+      V_index (int)
+        Index for the membrane potential among the state
+        variables, by default 0
 
     *Assumptions*
       * The cardiac conductivities do not vary in time
 
     """
-    def __init__(self, model, params=None):
+    def __init__(self, model, params=None, V_index=0):
         "Create solver from given Cardiac Model and (optional) parameters."
 
         assert isinstance(model, CardiacModel), \
@@ -120,6 +123,7 @@ class BasicSplittingSolver:
 
         # Set model and parameters
         self._model = model
+        self._V_index = V_index
         self.parameters = self.default_parameters()
         if params is not None:
             self.parameters.update(params)
@@ -143,7 +147,7 @@ class BasicSplittingSolver:
         else:
             V = self.vur.function_space()
 
-        self.merger = FunctionAssigner(self.VS.sub(0), V)
+        self.merger = FunctionAssigner(self.VS.sub(self._V_index), V)
 
         self._annotate_kwargs = annotate_kwargs(self.parameters)
 
@@ -194,12 +198,12 @@ class BasicSplittingSolver:
             params = self.parameters["BasicBidomainSolver"]
             args = (self._domain, self._time, M_i, M_e)
             kwargs = dict(I_s=stimulus, I_a=applied_current,
-                          v_=self.vs[0], params=params)
+                          v_=self.vs[self._V_index], params=params)
         else:
             PDESolver = BasicMonodomainSolver
             params = self.parameters["BasicMonodomainSolver"]
             args = (self._domain, self._time, M_i)
-            kwargs = dict(I_s=stimulus, v_=self.vs[0], params=params)
+            kwargs = dict(I_s=stimulus, v_=self.vs[self._V_index], params=params)
 
         # Propagate enable_adjoint to Bidomain solver
         if params.has_parameter("enable_adjoint"):
@@ -386,7 +390,7 @@ class BasicSplittingSolver:
             v = self.vur.sub(0)
         else:
             v = self.vur
-        self.merger.assign(solution.sub(0), v, **self._annotate_kwargs)
+        self.merger.assign(solution.sub(self._V_index), v, **self._annotate_kwargs)
         end()
 
         timer.stop()
@@ -463,9 +467,6 @@ class SplittingSolver(BasicSplittingSolver):
       * The cardiac conductivities do not vary in time
 
     """
-
-    def __init__(self, model, params=None):
-        BasicSplittingSolver.__init__(self, model, params)
 
     @staticmethod
     def default_parameters():
@@ -560,12 +561,12 @@ class SplittingSolver(BasicSplittingSolver):
             params = self.parameters["BidomainSolver"]
             args = (self._domain, self._time, M_i, M_e)
             kwargs = dict(I_s=stimulus, I_a=applied_current,
-                          v_=self.vs[0], params=params)
+                          v_=self.vs[self._V_index], params=params)
         else:
             PDESolver = MonodomainSolver
             params = self.parameters["MonodomainSolver"]
             args = (self._domain, self._time, M_i)
-            kwargs = dict(I_s=stimulus, v_=self.vs[0], params=params)
+            kwargs = dict(I_s=stimulus, v_=self.vs[self._V_index], params=params)
 
         # Propagate enable_adjoint to Bidomain solver
         if params.has_parameter("enable_adjoint"):

--- a/setup.py
+++ b/setup.py
@@ -11,6 +11,7 @@ minor = 1.1
 requirements = []
 extras_require={
     "gotran": ["gotran"],
+    "goss": ["pygoss"],
     "test": ["pytest", "matplotlib", "pytest-cov"],
     "docs": ["sphinx", "sphinx_book_theme"]
 }

--- a/test/pytest.ini
+++ b/test/pytest.ini
@@ -6,3 +6,4 @@ markers =
     adjoint: mark a test as using adjoint
     disabled: mark test as disabled
     xfail: mark test as failing 
+    goss: mark test as using goss

--- a/test/pytest.ini
+++ b/test/pytest.ini
@@ -1,0 +1,8 @@
+[pytest]
+markers =
+    fast: mark a test as fast
+    medium: mark a test as medium 
+    slow: mark a test as slow 
+    adjoint: mark a test as using adjoint
+    disabled: mark test as disabled
+    xfail: mark test as failing 

--- a/test/unit/test_gossplittingsolver.py
+++ b/test/unit/test_gossplittingsolver.py
@@ -1,0 +1,132 @@
+"""
+Unit tests for GOSS splitting solver
+"""
+
+__author__ = "Cécile Daversin Catty (cecile@simula.no), 2022"
+__all__ = ["TestGOSSplittingSolver"]
+
+from testutils import assert_almost_equal, medium, parametrize
+
+from dolfin import info
+
+from cbcbeat import *
+from cbcbeat.gossplittingsolver import GOSSplittingSolver
+
+import goss
+from goss.dolfinutils import DOLFINParameterizedODE
+
+try:
+    set_log_level(LogLevel.WARNING)
+except:
+    set_log_level(WARNING)
+    pass
+
+
+class TestSplittingSolver(object):
+    "Test functionality for the splitting solvers."
+
+    def setup(self):
+        self.mesh = UnitCubeMesh(5, 5, 5)
+
+        # Create time
+        self.time = Constant(0.0)
+
+        # Create stimulus
+        self.stimulus = Expression("2.0*t", t=self.time, degree=1)
+
+        # Create ac
+        self.applied_current = Expression("sin(2*pi*x[0])*t", t=self.time,
+                                          degree=3)
+
+        # Create conductivity "tensors"
+        self.M_i = 1.0
+        self.M_e = 2.0
+
+        # Splitting Solver cell and cardiac models
+        self.cell_model = FitzHughNagumoManual()
+        self.cardiac_model = CardiacModel(self.mesh, self.time,
+                                          self.M_i, self.M_e,
+                                          self.cell_model,
+                                          self.stimulus,
+                                          self.applied_current)
+
+        # GOSS Splitting Solver cell and cardiac models (expect different object)
+        self.goss_cell_model = goss.dolfinutils.DOLFINParameterizedODE(
+            "../../cbcbeat/cellmodels/fitzhughnagumo",
+            field_states=["v", "s"])
+
+        self.goss_cardiac_model = CardiacModel(self.mesh, self.time,
+                                               self.M_i, self.M_e,
+                                               self.goss_cell_model,
+                                               self.stimulus,
+                                               self.applied_current)
+
+        dt = 0.1
+        self.t0 = 0.0
+        self.dt = [(0.0, dt), (dt*2, dt/2), (dt*4, dt)]
+        # Test using variable dt interval but using the same dt.
+
+        self.T = self.t0 + 5*dt
+        self.ics = self.cell_model.initial_conditions()
+
+    @medium
+    @parametrize(("solver_type"), ["direct", "iterative"])
+    def test_basic_and_optimised_goss_splitting_solver_exact(self, solver_type):
+        """Test that basic and optimised splitting solvers yield
+        very comparative results when configured identically."""
+
+        # Create GOSS splitting solver
+        params = SplittingSolver.default_parameters()
+        params["BasicCardiacODESolver"]["S_polynomial_family"] = "CG"
+        params["BasicCardiacODESolver"]["S_polynomial_degree"] = 1
+        solver = SplittingSolver(self.cardiac_model, params=params)
+        
+        (vs_, vs, vur) = solver.solution_fields()
+        vs_.assign(self.ics)
+
+        # Solve
+        solutions = solver.solve((self.t0, self.T), self.dt)
+        for (interval, fields) in solutions:
+            (vs_, vs, vur) = fields
+        a = vs.vector().norm("l2")
+        c = vur.vector().norm("l2")
+        assert_almost_equal(interval[1], self.T, 1e-10)
+
+        if dolfin_adjoint:
+            adj_reset()
+
+        # Create optimised solver with direct solution algorithm
+        params = GOSSplittingSolver.default_parameters()
+        params["BidomainSolver"]["linear_solver_type"] = solver_type
+        params["enable_adjoint"] = False
+        if solver_type == "direct":
+            params["BidomainSolver"]["use_avg_u_constraint"] = True
+        solver = GOSSplittingSolver(self.goss_cardiac_model, params=params)
+
+        (vs_, vs, vur) = solver.solution_fields()
+
+        # Solve again
+        solutions = solver.solve((self.t0, self.T), self.dt)
+        for (interval, fields) in solutions:
+            (vs_, vs, vur) = fields
+        assert_almost_equal(interval[1], self.T, 1e-10)
+        b = vs.vector().norm("l2")
+        d = vur.vector().norm("l2")
+
+        print("a, b = ", a, b)
+        print("c, d = ", c, d)
+        print("a - b = ", (a - b))
+        print("c - d = ", (c - d))
+
+        err_ab = abs((a-b)*100/a)
+        err_cd = abs((c-d)*100/c)
+        print("Error a - b = ", err_ab, "%")
+        print("Error c - d = ", err_cd, "%")
+
+        # Compare results, discrepancy is in difference in ODE
+        # solves.
+        assert_almost_equal(a, b, tolerance=5.)
+        assert_almost_equal(c, d, tolerance=5.)
+        # Discrepancy in % (less than 1% error)
+        assert_almost_equal(err_ab, 0, tolerance=1.)
+        assert_almost_equal(err_cd, 0, tolerance=1.)

--- a/test/unit/test_gossplittingsolver.py
+++ b/test/unit/test_gossplittingsolver.py
@@ -5,21 +5,22 @@ Unit tests for GOSS splitting solver
 __author__ = "Cécile Daversin Catty (cecile@simula.no), 2022"
 __all__ = ["TestGOSSplittingSolver"]
 
-from testutils import assert_almost_equal, medium, parametrize
-
-from dolfin import info
+import pytest
+from pathlib import Path
+from testutils import assert_almost_equal, medium, parametrize, require_goss
 
 from cbcbeat import *
 from cbcbeat.gossplittingsolver import GOSSplittingSolver
 
-import goss
-from goss.dolfinutils import DOLFINParameterizedODE
 
 try:
     set_log_level(LogLevel.WARNING)
 except:
     set_log_level(WARNING)
     pass
+
+
+here = Path(__file__).parent.absolute()
 
 
 class TestSplittingSolver(object):
@@ -35,8 +36,7 @@ class TestSplittingSolver(object):
         self.stimulus = Expression("2.0*t", t=self.time, degree=1)
 
         # Create ac
-        self.applied_current = Expression("sin(2*pi*x[0])*t", t=self.time,
-                                          degree=3)
+        self.applied_current = Expression("sin(2*pi*x[0])*t", t=self.time, degree=3)
 
         # Create conductivity "tensors"
         self.M_i = 1.0
@@ -44,31 +44,43 @@ class TestSplittingSolver(object):
 
         # Splitting Solver cell and cardiac models
         self.cell_model = FitzHughNagumoManual()
-        self.cardiac_model = CardiacModel(self.mesh, self.time,
-                                          self.M_i, self.M_e,
-                                          self.cell_model,
-                                          self.stimulus,
-                                          self.applied_current)
+        self.cardiac_model = CardiacModel(
+            self.mesh,
+            self.time,
+            self.M_i,
+            self.M_e,
+            self.cell_model,
+            self.stimulus,
+            self.applied_current,
+        )
+        import goss
 
         # GOSS Splitting Solver cell and cardiac models (expect different object)
         self.goss_cell_model = goss.dolfinutils.DOLFINParameterizedODE(
-            "../../cbcbeat/cellmodels/fitzhughnagumo",
-            field_states=["v", "s"])
+            here.joinpath("../../cbcbeat/cellmodels/fitzhughnagumo"),
+            field_states=["v", "s"],
+        )
 
-        self.goss_cardiac_model = CardiacModel(self.mesh, self.time,
-                                               self.M_i, self.M_e,
-                                               self.goss_cell_model,
-                                               self.stimulus,
-                                               self.applied_current)
+        self.goss_cardiac_model = CardiacModel(
+            self.mesh,
+            self.time,
+            self.M_i,
+            self.M_e,
+            self.goss_cell_model,
+            self.stimulus,
+            self.applied_current,
+        )
 
         dt = 0.1
         self.t0 = 0.0
-        self.dt = [(0.0, dt), (dt*2, dt/2), (dt*4, dt)]
+        self.dt = [(0.0, dt), (dt * 2, dt / 2), (dt * 4, dt)]
         # Test using variable dt interval but using the same dt.
 
-        self.T = self.t0 + 5*dt
+        self.T = self.t0 + 5 * dt
         self.ics = self.cell_model.initial_conditions()
 
+    @require_goss
+    @pytest.mark.goss
     @medium
     @parametrize(("solver_type"), ["direct", "iterative"])
     def test_basic_and_optimised_goss_splitting_solver_exact(self, solver_type):
@@ -77,10 +89,12 @@ class TestSplittingSolver(object):
 
         # Create GOSS splitting solver
         params = SplittingSolver.default_parameters()
+        params["enable_adjoint"] = False
         params["BasicCardiacODESolver"]["S_polynomial_family"] = "CG"
         params["BasicCardiacODESolver"]["S_polynomial_degree"] = 1
+        params["CardiacODESolver"]["scheme"] = "RL1"
         solver = SplittingSolver(self.cardiac_model, params=params)
-        
+
         (vs_, vs, vur) = solver.solution_fields()
         vs_.assign(self.ics)
 
@@ -88,12 +102,12 @@ class TestSplittingSolver(object):
         solutions = solver.solve((self.t0, self.T), self.dt)
         for (interval, fields) in solutions:
             (vs_, vs, vur) = fields
-        a = vs.vector().norm("l2")
-        c = vur.vector().norm("l2")
-        assert_almost_equal(interval[1], self.T, 1e-10)
 
-        if dolfin_adjoint:
-            adj_reset()
+        vs_original = vs
+        vur_original = vur
+        a = vs_original.vector().norm("l2")
+        c = vur_original.vector().norm("l2")
+        assert_almost_equal(interval[1], self.T, 1e-10)
 
         # Create optimised solver with direct solution algorithm
         params = GOSSplittingSolver.default_parameters()
@@ -101,32 +115,37 @@ class TestSplittingSolver(object):
         params["enable_adjoint"] = False
         if solver_type == "direct":
             params["BidomainSolver"]["use_avg_u_constraint"] = True
+        params["ode_solver"]["solver"] = "RL1"
         solver = GOSSplittingSolver(self.goss_cardiac_model, params=params)
 
         (vs_, vs, vur) = solver.solution_fields()
+        vs_.assign(self.goss_cell_model.initial_conditions())
 
         # Solve again
         solutions = solver.solve((self.t0, self.T), self.dt)
         for (interval, fields) in solutions:
             (vs_, vs, vur) = fields
         assert_almost_equal(interval[1], self.T, 1e-10)
-        b = vs.vector().norm("l2")
-        d = vur.vector().norm("l2")
+
+        vs_goss = vs
+        vur_goss = vur
+        b = vs_goss.vector().norm("l2")
+        d = vur_goss.vector().norm("l2")
 
         print("a, b = ", a, b)
         print("c, d = ", c, d)
         print("a - b = ", (a - b))
         print("c - d = ", (c - d))
 
-        err_ab = abs((a-b)*100/a)
-        err_cd = abs((c-d)*100/c)
+        err_ab = abs((a - b) * 100 / a)
+        err_cd = abs((c - d) * 100 / c)
         print("Error a - b = ", err_ab, "%")
         print("Error c - d = ", err_cd, "%")
 
         # Compare results, discrepancy is in difference in ODE
         # solves.
-        assert_almost_equal(a, b, tolerance=5.)
-        assert_almost_equal(c, d, tolerance=5.)
+        assert_almost_equal(a, b, tolerance=5.0)
+        assert_almost_equal(c, d, tolerance=5.0)
         # Discrepancy in % (less than 1% error)
-        assert_almost_equal(err_ab, 0, tolerance=1.)
-        assert_almost_equal(err_cd, 0, tolerance=1.)
+        assert_almost_equal(err_ab, 0, tolerance=1.0)
+        assert_almost_equal(err_cd, 0, tolerance=1.0)

--- a/test/unit/test_gossplittingsolver_mms.py
+++ b/test/unit/test_gossplittingsolver_mms.py
@@ -1,0 +1,156 @@
+"""
+Verify the correctness of the test splitting solver with an analytic solution
+"""
+
+__author__ = "Simon W. Funke (simon@simula.no) and Jakob Schreiner, 2018"
+
+import pytest
+import cbcbeat
+
+from testutils import medium
+from collections import OrderedDict
+from cbcbeat import cellmodels
+from cbcbeat.gossplittingsolver import GOSSplittingSolver
+from cbcbeat.dolfinimport import Expression, Constant, UnitSquareMesh
+from cbcbeat import BidomainSolver, errornorm, CardiacCellModel
+from cbcbeat.utils import convergence_rate
+
+import goss
+from goss.dolfinutils import DOLFINParameterizedODE
+
+class SimpleODEModel(CardiacCellModel):
+    """This class implements a simple ODE system """
+    def __init__(self, mesh):
+        CardiacCellModel.__init__(self)
+
+    def I(self, v, s, time=None):
+        return -s
+
+    def F(self, v, s, time=None):
+        return v
+
+    @staticmethod
+    def default_initial_conditions():
+        return OrderedDict([("V", 0.0),("S", 0.0)])
+
+    def num_states(self):
+        return 1
+
+
+def main(N, dt, T, theta=0.5):
+    """Run bidomain MMA."""
+
+    # Exact solutions
+    u_exact_str = "-cos(pi*x[0])*cos(pi*x[1])*sin(t)/2.0"
+    v_exact_str = "cos(pi*x[0])*cos(pi*x[1])*sin(t)"
+    s_exact_str = "-cos(pi*x[0])*cos(pi*x[1])*cos(t)"
+
+    # Source term
+    ac_str = "cos(t)*cos(pi*x[0])*cos(pi*x[1]) + pow(pi, 2)*cos(pi*x[0])*cos(pi*x[1])*sin(t)"
+    ac_str +=" - " + s_exact_str
+
+    # Create data
+    mesh = UnitSquareMesh(N, N)
+    time = Constant(0.0)
+
+    # We choose the FHN parameters such that s=1 and I_s=v
+    #model = SimpleODEModel(mesh)
+    model = goss.dolfinutils.DOLFINParameterizedODE(
+        "../../cbcbeat/cellmodels/simple_model",
+        field_states=["v", "s"])
+
+    model.set_initial_conditions(v=0, s=Expression(s_exact_str, degree=5, t=0))    # Set initial co
+    ps = GOSSplittingSolver.default_parameters()
+    ps["pde_solver"] = "bidomain"
+    ps["theta"] = theta
+    ps["ode_solver"]["solver"] = "RK4"
+    ps["enable_adjoint"] = False
+    ps["BidomainSolver"]["linear_solver_type"] = "direct"
+    ps["BidomainSolver"]["use_avg_u_constraint"] = True
+    ps["apply_stimulus_current_to_pde"] = True
+
+
+    stimulus = Expression(ac_str, t=time, dt=dt, degree=5)
+    M_i = 1.0
+    M_e = 1.0
+    heart = cbcbeat.CardiacModel(mesh, time, M_i, M_e, model, stimulus)
+    splittingsolver = GOSSplittingSolver(heart, params=ps)
+
+
+    # Define exact solution (Note: v is returned at end of time
+    # interval(s), u is computed at somewhere in the time interval
+    # depending on theta)
+    
+    v_exact = Expression(v_exact_str, t=T, degree=3)
+    u_exact = Expression(
+        u_exact_str,
+        t=T - (1. - theta)*dt,
+        degree=3
+    )
+
+
+    pde_vs_, pde_vs, vur = splittingsolver.solution_fields()
+    #pde_vs_.assign(model.initial_conditions())
+
+    solutions = splittingsolver.solve((0, T), dt)
+    for (t0, t1), (vs_, vs, vur) in solutions:
+        pass
+
+    # Compute errors
+    v = vs.split(deepcopy=True)[0]
+    u = vur.split(deepcopy=True)[1]
+    v_error = errornorm(v_exact, v, "L2", degree_rise=2)
+    u_error = errornorm(u_exact, u, "L2", degree_rise=2)
+    return v_error, u_error, mesh.hmin(), dt, T
+
+@medium
+def test_spatial_convergence():
+    """Take a very small timestep, reduce mesh size, expect 2nd order convergence."""
+    v_errors = []
+    u_errors = []
+    hs = []
+    dt = 0.01
+    T = 1.0
+    for N in (5, 10, 20, 40):
+        v_error, u_error, h, dt_, T = main(N, dt, T)   
+        v_errors.append(v_error)
+        u_errors.append(u_error)
+        hs.append(h)
+
+    v_rates = convergence_rate(hs, v_errors)
+    u_rates = convergence_rate(hs, u_errors)
+    print("dt, T = ", dt, T)
+    print("v_errors = ", v_errors)
+    print("u_errors = ", u_errors)
+    print("v_rates = ", v_rates)
+    print("u_rates = ", u_rates)
+
+    assert all(v > 1.9 for v in v_rates), "Failed convergence for v"
+    assert all(u > 1.85 for u in u_rates), "Failed convergence for u"
+
+@medium
+def test_temporal_convergence():
+    """Take a small mesh, reduce timestep size, expect 2nd order convergence."""
+    v_errors = []
+    u_errors = []
+    dts = []
+    dt = 1.0
+    T = 1.0
+    N = 150
+    for level in (0, 1, 2, 3):
+        a = dt/(2**level)
+        v_error, u_error, h, a, T = main(N, a, T)
+        v_errors.append(v_error)
+        u_errors.append(u_error)
+        dts.append(a)
+
+    v_rates = convergence_rate(dts, v_errors)
+    u_rates = convergence_rate(dts, u_errors)
+    print("v_errors = ", v_errors)
+    print("u_errors = ", u_errors)
+    print("v_rates = ", v_rates)
+    print("u_rates = ", u_rates)
+
+    assert v_rates[-1] > 1.95, "Failed convergence for v"
+    # Increase spatial resolution to get better temporal convergence for u
+    assert u_rates[-1] > 1.78, "Failed convergence for u"

--- a/test/unit/test_gossplittingsolver_mms.py
+++ b/test/unit/test_gossplittingsolver_mms.py
@@ -8,7 +8,7 @@ import cbcbeat
 from pathlib import Path
 
 
-from testutils import medium
+from testutils import medium, require_goss
 from cbcbeat.gossplittingsolver import GOSSplittingSolver
 from cbcbeat.dolfinimport import (
     Expression,
@@ -18,17 +18,6 @@ from cbcbeat.dolfinimport import (
 from cbcbeat import errornorm
 from cbcbeat.utils import convergence_rate
 
-try:
-    import goss
-
-    has_goss = True
-except ImportError:
-    has_goss = False
-
-require_goss = pytest.mark.skipif(
-    not has_goss,
-    reason="goss is required to run the test",
-)
 
 here = Path(__file__).parent.absolute()
 
@@ -49,7 +38,7 @@ def main(N, dt, T, theta=0.5):
     # Create data
     mesh = UnitSquareMesh(N, N)
     time = Constant(0.0)
-    # V = FunctionSpace(mesh, "CG", 1)
+    import goss
 
     # We choose the FHN parameters such that s=1 and I_s=v
     model = goss.dolfinutils.DOLFINParameterizedODE(

--- a/test/unit/test_gossplittingsolver_mms.py
+++ b/test/unit/test_gossplittingsolver_mms.py
@@ -3,38 +3,34 @@ Verify the correctness of the test splitting solver with an analytic solution
 """
 
 __author__ = "Simon W. Funke (simon@simula.no) and Jakob Schreiner, 2018"
-
 import pytest
 import cbcbeat
+from pathlib import Path
+
 
 from testutils import medium
-from collections import OrderedDict
-from cbcbeat import cellmodels
 from cbcbeat.gossplittingsolver import GOSSplittingSolver
-from cbcbeat.dolfinimport import Expression, Constant, UnitSquareMesh
-from cbcbeat import BidomainSolver, errornorm, CardiacCellModel
+from cbcbeat.dolfinimport import (
+    Expression,
+    Constant,
+    UnitSquareMesh,
+)
+from cbcbeat import errornorm
 from cbcbeat.utils import convergence_rate
 
-import goss
-from goss.dolfinutils import DOLFINParameterizedODE
+try:
+    import goss
 
-class SimpleODEModel(CardiacCellModel):
-    """This class implements a simple ODE system """
-    def __init__(self, mesh):
-        CardiacCellModel.__init__(self)
+    has_goss = True
+except ImportError:
+    has_goss = False
 
-    def I(self, v, s, time=None):
-        return -s
+require_goss = pytest.mark.skipif(
+    not has_goss,
+    reason="goss is required to run the test",
+)
 
-    def F(self, v, s, time=None):
-        return v
-
-    @staticmethod
-    def default_initial_conditions():
-        return OrderedDict([("V", 0.0),("S", 0.0)])
-
-    def num_states(self):
-        return 1
+here = Path(__file__).parent.absolute()
 
 
 def main(N, dt, T, theta=0.5):
@@ -46,20 +42,22 @@ def main(N, dt, T, theta=0.5):
     s_exact_str = "-cos(pi*x[0])*cos(pi*x[1])*cos(t)"
 
     # Source term
-    ac_str = "cos(t)*cos(pi*x[0])*cos(pi*x[1]) + pow(pi, 2)*cos(pi*x[0])*cos(pi*x[1])*sin(t)"
-    ac_str +=" - " + s_exact_str
-
+    ac_str = (
+        "cos(t)*cos(pi*x[0])*cos(pi*x[1]) + pow(pi, 2)*cos(pi*x[0])*cos(pi*x[1])*sin(t)"
+    )
+    ac_str += " - " + s_exact_str
     # Create data
     mesh = UnitSquareMesh(N, N)
     time = Constant(0.0)
+    # V = FunctionSpace(mesh, "CG", 1)
 
     # We choose the FHN parameters such that s=1 and I_s=v
-    #model = SimpleODEModel(mesh)
     model = goss.dolfinutils.DOLFINParameterizedODE(
-        "../../cbcbeat/cellmodels/simple_model",
-        field_states=["v", "s"])
+        here.joinpath("../../cbcbeat/cellmodels/simple_model"), field_states=["v", "s"]
+    )
 
-    model.set_initial_conditions(v=0, s=Expression(s_exact_str, degree=5, t=0))    # Set initial co
+    model.set_initial_conditions(v=0, s=Expression(s_exact_str, degree=5, t=0))
+
     ps = GOSSplittingSolver.default_parameters()
     ps["pde_solver"] = "bidomain"
     ps["theta"] = theta
@@ -69,40 +67,35 @@ def main(N, dt, T, theta=0.5):
     ps["BidomainSolver"]["use_avg_u_constraint"] = True
     ps["apply_stimulus_current_to_pde"] = True
 
-
     stimulus = Expression(ac_str, t=time, dt=dt, degree=5)
     M_i = 1.0
     M_e = 1.0
     heart = cbcbeat.CardiacModel(mesh, time, M_i, M_e, model, stimulus)
     splittingsolver = GOSSplittingSolver(heart, params=ps)
 
-
     # Define exact solution (Note: v is returned at end of time
     # interval(s), u is computed at somewhere in the time interval
     # depending on theta)
-    
-    v_exact = Expression(v_exact_str, t=T, degree=3)
-    u_exact = Expression(
-        u_exact_str,
-        t=T - (1. - theta)*dt,
-        degree=3
-    )
-
+    v_exact = Expression(v_exact_str, t=T, degree=1)
+    u_exact = Expression(u_exact_str, t=T - (1.0 - theta) * dt, degree=3)
 
     pde_vs_, pde_vs, vur = splittingsolver.solution_fields()
-    #pde_vs_.assign(model.initial_conditions())
+    pde_vs_.assign(model.initial_conditions())
 
     solutions = splittingsolver.solve((0, T), dt)
     for (t0, t1), (vs_, vs, vur) in solutions:
         pass
-
     # Compute errors
     v = vs.split(deepcopy=True)[0]
     u = vur.split(deepcopy=True)[1]
     v_error = errornorm(v_exact, v, "L2", degree_rise=2)
     u_error = errornorm(u_exact, u, "L2", degree_rise=2)
+
     return v_error, u_error, mesh.hmin(), dt, T
 
+
+@require_goss
+@pytest.mark.goss
 @medium
 def test_spatial_convergence():
     """Take a very small timestep, reduce mesh size, expect 2nd order convergence."""
@@ -112,7 +105,7 @@ def test_spatial_convergence():
     dt = 0.01
     T = 1.0
     for N in (5, 10, 20, 40):
-        v_error, u_error, h, dt_, T = main(N, dt, T)   
+        v_error, u_error, h, dt_, T = main(N, dt, T)
         v_errors.append(v_error)
         u_errors.append(u_error)
         hs.append(h)
@@ -128,6 +121,9 @@ def test_spatial_convergence():
     assert all(v > 1.9 for v in v_rates), "Failed convergence for v"
     assert all(u > 1.85 for u in u_rates), "Failed convergence for u"
 
+
+@require_goss
+@pytest.mark.goss
 @medium
 def test_temporal_convergence():
     """Take a small mesh, reduce timestep size, expect 2nd order convergence."""
@@ -138,7 +134,7 @@ def test_temporal_convergence():
     T = 1.0
     N = 150
     for level in (0, 1, 2, 3):
-        a = dt/(2**level)
+        a = dt / (2**level)
         v_error, u_error, h, a, T = main(N, a, T)
         v_errors.append(v_error)
         u_errors.append(u_error)

--- a/test/unit/testutils.py
+++ b/test/unit/testutils.py
@@ -8,6 +8,18 @@ import pytest
 from cbcbeat.cellmodels import *
 from cbcbeat.utils import state_space
 
+try:
+    import goss
+
+    has_goss = True
+except ImportError:
+    has_goss = False
+
+require_goss = pytest.mark.skipif(
+    not has_goss,
+    reason="goss is required to run the test",
+)
+
 # Marks
 fast = pytest.mark.fast
 medium = pytest.mark.medium
@@ -26,23 +38,28 @@ def assert_almost_equal(a, b, tolerance):
         c_inf = numpy.linalg.norm(c, numpy.inf)
         assert c_inf < tolerance
 
+
 def assert_equal(a, b):
     assert a == b
+
 
 def assert_true(a):
     assert a is True
 
+
 def assert_greater(a, b):
     assert a > b
 
+
 # Fixtures
-supported_cell_models_str = [Model.__name__
-                             for Model in supported_cell_models]
+supported_cell_models_str = [Model.__name__ for Model in supported_cell_models]
+
 
 @pytest.fixture(params=supported_cell_models_str)
 def cell_model(request):
     Model = eval(request.param)
     return Model()
+
 
 @pytest.fixture(params=supported_cell_models_str)
 def ode_test_form(request):
@@ -57,6 +74,6 @@ def ode_test_form(request):
     vs.assign(project(model.initial_conditions(), VS))
     (v, s) = split(vs)
     (w, r) = TestFunctions(VS)
-    rhs = inner(model.F(v, s), r) + inner(- model.I(v, s), w)
-    form = rhs*dP
+    rhs = inner(model.F(v, s), r) + inner(-model.I(v, s), w)
+    form = rhs * dP
     return form


### PR DESCRIPTION
In this PR I make a lot of changes to `GOSSplittingsolver` be basically inheriting most methods from the regular SplittingSolver.
I also make it possible to pass only a single cell model. Before you needed to use the `MultiCellModel` even tough you only had a single cell model.

Also, I do a few adjustments to the regular SplittingSolver and allow for the membrane potential ("V") coming from the ODE solver to 
1) Not needing to be the first state. Currently it is assumed that "V" is the first index in the space of solutions from the ODE
2) "V" can be the only state variable in the ODE solution meaning that "V" does not lie in a subspace
